### PR TITLE
Model updates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,13 @@
+name: Verify Library
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build with Maven
+        run: mvn verify

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,9 @@
 MIT License
 
-Copyright (c) CodeScan Enterprises LLC and its affiliates.
+Copyright for portions of project VillageChief/sarif-java are held by [CodeScan
+Enterprises LLC, 2020] as part of project this project
+Contrast-Security-OSS/sarif-java. All other copyright for project
+Contrast-Security-OSS/sarif-java  are held by [Contrast Security Inc, 2020].  
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,9 @@
 
   <properties>
     <java.version>1.8</java.version>
+    <junit.jupiter.version>5.6.2</junit.jupiter.version>
+    <lombok.version>1.18.2</lombok.version>
+    <jackson.databind.version>2.11.2</jackson.databind.version>
   </properties>
 
   <licenses>
@@ -26,13 +29,20 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.11.2</version>
+      <version>${jackson.databind.version}</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.12</version>
+      <version>${lombok.version}</version>
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${junit.jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -43,8 +53,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.codescan</groupId>
+  <groupId>com.contrastsecurity</groupId>
   <artifactId>sarif-java</artifactId>
   <version>1.0</version>
   <name>sarif-java</name>
@@ -21,21 +21,6 @@
       <url>http://www.opensource.org/licenses/mit-license.php</url>
     </license>
   </licenses>
-
-  <developers>
-    <developer>
-      <name>Barys Yakavita</name>
-      <email>barys.yakavita@codescan.io</email>
-      <organization>CodeScan Enterprises LLC</organization>
-      <organizationUrl>https://codescan.io</organizationUrl>
-    </developer>
-  </developers>
-
-  <scm>
-    <connection>scm:git:git://github.com/VillageChief/sarif-java.git</connection>
-    <developerConnection>scm:git:ssh://github.com:VillageChief/sarif-java.git</developerConnection>
-    <url>https://github.com/VillageChief/sarif-java/tree/master</url>
-  </scm>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,10 +6,10 @@
 
   <groupId>com.contrastsecurity</groupId>
   <artifactId>sarif-java</artifactId>
-  <version>1.0</version>
+  <version>1.0.0</version>
   <name>sarif-java</name>
   <description>Library provides POJO classes used to build SARIF model.</description>
-  <url>https://github.com/VillageChief/sarif-java</url>
+  <url>https://github.com/Contrast-Security-OSS/sarif-java</url>
 
   <properties>
     <java.version>1.8</java.version>
@@ -47,71 +47,19 @@
           <target>1.8</target>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <id>attach-sources</id>
-            <goals>
-              <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <source>8</source>
-        </configuration>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
 
   <distributionManagement>
     <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <id>contrast-artifactory</id>
+      <name>umbrella-releases</name>
+      <url>https://contrastsecurity.jfrog.io/contrastsecurity/maven-umbrella</url>
     </repository>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <id>contrast-artifactory</id>
+      <name>umbrella-snapshots</name>
+      <url>https://contrastsecurity.jfrog.io/contrastsecurity/maven-umbrella</url>
     </snapshotRepository>
   </distributionManagement>
 </project>

--- a/src/main/java/io/codescan/sarif/encoding/InstantSerializer.java
+++ b/src/main/java/io/codescan/sarif/encoding/InstantSerializer.java
@@ -1,0 +1,27 @@
+package io.codescan.sarif.encoding;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatterBuilder;
+
+
+public class InstantSerializer extends StdSerializer<Instant> {
+    public InstantSerializer() {
+        this(null);
+    }
+
+    public InstantSerializer(Class<Instant> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Instant instant, JsonGenerator jsonGenerator, SerializerProvider serializer) throws IOException {
+        //TODO: convert 'instant' to utc date-time sarif format.
+        var fmt = new DateTimeFormatterBuilder().appendInstant().toFormatter();
+        jsonGenerator.writeString(fmt.format(instant));
+    }
+}

--- a/src/main/java/io/codescan/sarif/encoding/PropertyBagSerializer.java
+++ b/src/main/java/io/codescan/sarif/encoding/PropertyBagSerializer.java
@@ -1,0 +1,45 @@
+package io.codescan.sarif.encoding;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import io.codescan.sarif.model.PropertyBag;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class PropertyBagSerializer extends StdSerializer<PropertyBag> {
+    public PropertyBagSerializer() {
+        this(null);
+    }
+
+    public PropertyBagSerializer(Class<PropertyBag> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(PropertyBag properties, JsonGenerator jsonGenerator, SerializerProvider serializer) throws IOException {
+        Map<String, String> props = properties.getProperties();
+        Set<String> tags = properties.getTags();
+
+        jsonGenerator.writeStartObject();
+
+        if (props != null) {
+            for (Map.Entry<String, String> entry: props.entrySet()) {
+                jsonGenerator.writeStringField(entry.getKey(), entry.getValue());
+            }
+        }
+
+        if (tags != null) {
+            jsonGenerator.writeArrayFieldStart("tags");
+            for (String val : tags) {
+                jsonGenerator.writeString(val);
+            }
+            jsonGenerator.writeEndArray();
+        }
+
+        jsonGenerator.writeEndObject();
+    }
+}

--- a/src/main/java/io/codescan/sarif/encoding/SarifJsonSerializer.java
+++ b/src/main/java/io/codescan/sarif/encoding/SarifJsonSerializer.java
@@ -7,6 +7,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.codescan.sarif.model.PropertyBag;
 
+import java.time.Instant;
+
 public class SarifJsonSerializer {
 
     private SarifJsonSerializer() {}
@@ -16,8 +18,9 @@ public class SarifJsonSerializer {
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
 
         SimpleModule module =
-                new SimpleModule("PropertyBagSerializer", new Version(1, 0, 0, null, null, null));
+                new SimpleModule("CustomSerializers", new Version(1, 0, 0, null, null, null));
         module.addSerializer(PropertyBag.class, new PropertyBagSerializer());
+        module.addSerializer(Instant.class, new InstantSerializer()); // handle sarif data-time format
         mapper.registerModule(module);
 
         final String sarifJson = mapper.writeValueAsString(obj);

--- a/src/main/java/io/codescan/sarif/encoding/SarifJsonSerializer.java
+++ b/src/main/java/io/codescan/sarif/encoding/SarifJsonSerializer.java
@@ -1,0 +1,26 @@
+package io.codescan.sarif.encoding;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.codescan.sarif.model.PropertyBag;
+
+public class SarifJsonSerializer {
+
+    private SarifJsonSerializer() {}
+
+    public static String toJson(Object obj) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        SimpleModule module =
+                new SimpleModule("PropertyBagSerializer", new Version(1, 0, 0, null, null, null));
+        module.addSerializer(PropertyBag.class, new PropertyBagSerializer());
+        mapper.registerModule(module);
+
+        final String sarifJson = mapper.writeValueAsString(obj);
+        return sarifJson;
+    }
+}

--- a/src/main/java/io/codescan/sarif/model/Address.java
+++ b/src/main/java/io/codescan/sarif/model/Address.java
@@ -1,11 +1,13 @@
 package io.codescan.sarif.model;
 
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 /**
  * A physical or virtual address, or a range of addresses, in an 'addressable region' (memory or a binary file).
  */
 @Data
+@Accessors(chain = true)
 public class Address {
 
     /**

--- a/src/main/java/io/codescan/sarif/model/Artifact.java
+++ b/src/main/java/io/codescan/sarif/model/Artifact.java
@@ -1,0 +1,40 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+
+@Data
+@Accessors(chain = true)
+public class Artifact {
+    /**
+     * A short description of the artifact.
+     */
+    private Message description;
+    /**
+     * The location of the artifact.
+     */
+    private ArtifactLocation location;
+    /**
+     * Identifies the index of the immediate parent of the artifact, if this artifact is nested.
+     */
+    private Integer parentIndex;
+    /**
+     * The offset in bytes of the artifact within its containing artifact.
+     */
+    private Integer offset;
+    /**
+     * The length of the artifact in bytes.
+     */
+    private Integer length;
+    /**
+     * Specifies the source language for any artifact object that refers to a text file that contains source code.
+     */
+    private String sourceLanguage;
+    /**
+     * A dictionary, each of whose keys is the name of a hash function and each of whose values is the hashed value of
+     * the artifact produced by the specified hash function.
+     */
+    private Map<String, String> hashes;
+}

--- a/src/main/java/io/codescan/sarif/model/BaselineState.java
+++ b/src/main/java/io/codescan/sarif/model/BaselineState.java
@@ -1,0 +1,17 @@
+package io.codescan.sarif.model;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum BaselineState {
+    @JsonProperty("new")
+    NEW,
+    @JsonProperty("unchanged")
+    UNCHANGED,
+    @JsonProperty("updated")
+    UPDATED,
+    @JsonProperty("absent")
+    ABSENT
+}

--- a/src/main/java/io/codescan/sarif/model/CodeFlow.java
+++ b/src/main/java/io/codescan/sarif/model/CodeFlow.java
@@ -1,0 +1,29 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+/**
+ * A set of threadFlows which together describe a pattern of code execution relevant to detecting a result.
+ */
+@Data
+@Accessors(chain = true)
+public class CodeFlow {
+    /**
+     * A message relevant to the code flow.
+     */
+    private Message message;
+    /**
+     * An array of one or more unique threadFlow objects, each of which describes the progress of a program through a
+     * thread of execution.
+     */
+    private List<ThreadFlow> threadFlows;
+
+    /**
+     * Key/value pairs that provide additional information about the code flow.
+     */
+    private PropertyBag properties;
+
+}

--- a/src/main/java/io/codescan/sarif/model/Conversion.java
+++ b/src/main/java/io/codescan/sarif/model/Conversion.java
@@ -1,0 +1,27 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class Conversion {
+    /**
+     * A tool object that describes the converter.
+     */
+    private Tool tool;
+    /**
+     * An invocation object that describes the invocation of the converter.
+     */
+    private Invocation invocation;
+    /**
+     * The locations of the analysis tool's per-run log files.
+     */
+    private List<ArtifactLocation> analysisToolLogFiles;
+    /**
+     * Key/value pairs that provide additional information about the conversion.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/Importance.java
+++ b/src/main/java/io/codescan/sarif/model/Importance.java
@@ -1,0 +1,12 @@
+package io.codescan.sarif.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Importance {
+    @JsonProperty("essential")
+    ESSENTIAL,
+    @JsonProperty("important")
+    IMPORTANT,
+    @JsonProperty("unimportant")
+    UNIMPORTANT
+}

--- a/src/main/java/io/codescan/sarif/model/Invocation.java
+++ b/src/main/java/io/codescan/sarif/model/Invocation.java
@@ -1,0 +1,122 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The runtime environment of the analysis tool run.
+ */
+@Data
+@Accessors(chain = true)
+public class Invocation {
+    /**
+     * The command line used to invoke the tool.
+     */
+    private String commandLine;
+    /**
+     * An array of strings, containing in order the command line arguments passed to the tool from the operating system.
+     */
+    private List<String> arguments;
+    /**
+     * The locations of any response files specified on the tool's command line.
+     */
+    private List<ArtifactLocation> responseFiles;
+    /**
+     * The Coordinated Universal Time (UTC) date and time at which the invocation started. See \"Date/time properties\"
+     * in the SARIF spec for the required format.
+     */
+    private Instant startTimeUtc;
+    /**
+     * The Coordinated Universal Time (UTC) date and time at which the invocation ended. See \"Date/time properties\"
+     * in the SARIF spec for the required format.
+     */
+    private Instant endTimeUtc;
+    /**
+     * The process exit code.
+     */
+    private Integer exitCode;
+    /**
+     * An array of configurationOverride objects that describe rules related runtime overrides.
+     */
+    //TODO: private List<ConfigurationOverride> ruleConfigurationOverrides;
+    /**
+     * An array of configurationOverride objects that describe notifications related runtime overrides.
+     */
+    //TODO: private List<ConfigurationOverride> notificationConfigurationOverrides;
+    /**
+     * A list of runtime conditions detected by the tool during the analysis.
+     */
+    private List<Notification> toolExecutionNotifications;
+    /**
+     * A list of conditions detected by the tool that are relevant to the tool's configuration.
+     */
+    private List<Notification> toolConfigurationNotifications;
+    /**
+     * The reason for the process exit.
+     */
+    private String exitCodeDescription;
+    /**
+     * The name of the signal that caused the process to exit.
+     */
+    private String exitSignalName;
+    /**
+     * The numeric value of the signal that caused the process to exit.
+     */
+    private Integer exitSignalNumber;
+    /**
+     * The reason given by the operating system that the process failed to start.
+     */
+    private String processStartFailureMessage;
+    /**
+     * Specifies whether the tool's execution completed successfully.
+     */
+    private Boolean executionSuccessful;
+    /**
+     * The machine on which the invocation occurred.
+     */
+    private String machine;
+    /**
+     * The account under which the invocation occurred.
+     */
+    private String account;
+    /**
+     * The id of the process in which the invocation occurred.
+     */
+    private Integer processId;
+    /**
+     * An absolute URI specifying the location of the executable that was invoked.
+     */
+    private ArtifactLocation executableLocation;
+    /**
+     * The working directory for the invocation.
+     */
+    private ArtifactLocation workingDirectory;
+    /**
+     * The environment variables associated with the analysis tool process, expressed as key/value pairs.
+     */
+    private Map<String, String> environmentVariables;
+    /**
+     * A file containing the standard input stream to the process that was invoked.
+     */
+    private ArtifactLocation stdin;
+    /**
+     * A file containing the standard output stream from the process that was invoked.
+     */
+    private ArtifactLocation stdout;
+    /**
+     * A file containing the standard error stream from the process that was invoked.
+     */
+    private ArtifactLocation stderr;
+    /**
+     * A file containing the interleaved standard output and standard error stream from the process that was invoked.
+     */
+    private ArtifactLocation stdoutStderr;
+    /**
+     * Key/value pairs that provide additional information about the invocation.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/Level.java
+++ b/src/main/java/io/codescan/sarif/model/Level.java
@@ -1,0 +1,14 @@
+package io.codescan.sarif.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum Level {
+    @JsonProperty("none")
+    NONE,
+    @JsonProperty("note")
+    NOTE,
+    @JsonProperty("warning")
+    WARNING,
+    @JsonProperty("error")
+    ERROR
+}

--- a/src/main/java/io/codescan/sarif/model/LogicalLocation.java
+++ b/src/main/java/io/codescan/sarif/model/LogicalLocation.java
@@ -5,6 +5,42 @@ import lombok.experimental.Accessors;
 
 @Data
 @Accessors(chain = true)
+/**
+ * A logical location of a construct that produced a result.
+ */
 public class LogicalLocation {
-
+    /**
+     * Identifies the construct in which the result occurred. For example, this property might contain the name of a
+     * class or a method.
+     */
+    private String name;
+    /**
+     * The index within the logical locations array.
+     */
+    private Integer index;
+    /**
+     * The human-readable fully qualified name of the logical location.
+     */
+    private String fullyQualifiedName;
+    /**
+     * The machine-readable name for the logical location, such as a mangled function name provided by a C++ compiler
+     * that encodes calling convention, return type and other details along with the function name.
+     */
+    private String decoratedName;
+    /**
+     * Identifies the index of the immediate parent of the construct in which the result was detected. For example,
+     * this property might point to a logical location that represents the namespace that holds a type.
+     */
+    private Integer parentIndex;
+    /**
+     * The type of construct this logical location component refers to. Should be one of 'function', 'member',
+     * 'module', 'namespace', 'parameter', 'resource', 'returnType', 'type', 'variable', 'object', 'array', 'property',
+     * 'value', 'element', 'text', 'attribute', 'comment', 'declaration', 'dtd' or 'processingInstruction', if any of
+     * those accurately describe the construct.
+     */
+    private String kind;
+    /**
+     * Key/value pairs that provide additional information about the logical location.
+     */
+    private PropertyBag properties;
 }

--- a/src/main/java/io/codescan/sarif/model/MultiformatMessageString.java
+++ b/src/main/java/io/codescan/sarif/model/MultiformatMessageString.java
@@ -3,6 +3,7 @@ package io.codescan.sarif.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
 
 /**
  * A message string or message format string rendered in multiple formats.
@@ -10,19 +11,23 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-public class MultiformatMessage {
+@Accessors(chain = true)
+public class MultiformatMessageString {
 
     /**
      * A plain text message string or format string.
      */
     private String text;
-
     /**
      * A Markdown message string or format string.
      */
     private String markdown;
+    /**
+     * Key/value pairs that provide additional information about the message.
+     */
+    private PropertyBag properties;
 
-    public MultiformatMessage(String text) {
+    public MultiformatMessageString(String text) {
         this.text = text;
     }
 }

--- a/src/main/java/io/codescan/sarif/model/Notification.java
+++ b/src/main/java/io/codescan/sarif/model/Notification.java
@@ -1,0 +1,52 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Describes a condition relevant to the tool itself, as opposed to being relevant to a target being analyzed by the
+ * tool.
+ */
+@Data
+@Accessors(chain = true)
+public class Notification {
+    /**
+     * The locations relevant to this notification.
+     */
+    private List<Location> locations;
+    /**
+     * A message that describes the condition that was encountered.
+     */
+    private Message message;
+    /**
+     * A value specifying the severity level of the notification.
+     */
+    private Level level;
+    /**
+     * The thread identifier of the code that generated the notification.
+     */
+    private Integer threadId;
+    /**
+     * The Coordinated Universal Time (UTC) date and time at which the analysis tool generated the notification.
+     */
+    private Instant timeUtc;
+    /**
+     * The runtime exception, if any, relevant to this notification.
+     */
+    //TODO: private Exception_ exception;
+    /**
+     * A reference used to locate the descriptor relevant to this notification.
+     */
+    private ReportingDescriptorReference descriptor;
+    /**
+     * A reference used to locate the rule descriptor associated with this notification.
+     */
+    private ReportingDescriptorReference associatedRule;
+    /**
+     * Key/value pairs that provide additional information about the notification.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/PropertyBag.java
+++ b/src/main/java/io/codescan/sarif/model/PropertyBag.java
@@ -1,16 +1,23 @@
 package io.codescan.sarif.model;
 
-import java.util.Set;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
 import lombok.Data;
+import lombok.experimental.Accessors;
 
 /**
  * Key/value pairs that provide additional information about the object.
  */
 @Data
+@Accessors(chain=true)
 public class PropertyBag {
 
+    Map<String, String> properties;
     /**
      * A set of distinct strings that provide additional information.
+     *
+     * The object is a LinkedHashSet implementation because lists in json are considered ordered.
      */
-    private Set<String> tags;
+    private LinkedHashSet<String> tags;
 }

--- a/src/main/java/io/codescan/sarif/model/ReportingDescriptor.java
+++ b/src/main/java/io/codescan/sarif/model/ReportingDescriptor.java
@@ -47,20 +47,20 @@ public class ReportingDescriptor {
      * A concise description of the report. Should be a single sentence that is understandable when visible space is
      * limited to a single line of text.
      */
-    private MultiformatMessage shortDescription;
+    private MultiformatMessageString shortDescription;
 
     /**
      * A description of the report. Should, as far as possible, provide details sufficient to enable resolution of any
      * problem indicated by the result.
      */
-    private MultiformatMessage fullDescription;
+    private MultiformatMessageString fullDescription;
 
     /**
      * A set of name/value pairs with arbitrary names. Each value is a multiformatMessageString object, which holds
      * message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can
      * be used to construct a message in combination with an arbitrary number of additional string arguments.
      */
-    private MultiformatMessage messageStrings;
+    private MultiformatMessageString messageStrings;
 
     /**
      * Default reporting configuration information.
@@ -75,7 +75,7 @@ public class ReportingDescriptor {
     /**
      * Provides the primary documentation for the report, useful when there is no online documentation.
      */
-    private MultiformatMessage help;
+    private MultiformatMessageString help;
 
     /**
      * An array of objects that describe relationships between this reporting descriptor and others.

--- a/src/main/java/io/codescan/sarif/model/ReportingDescriptor.java
+++ b/src/main/java/io/codescan/sarif/model/ReportingDescriptor.java
@@ -1,6 +1,8 @@
 package io.codescan.sarif.model;
 
 import java.util.List;
+import java.util.Map;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -60,7 +62,7 @@ public class ReportingDescriptor {
      * message strings in plain text and (optionally) Markdown format. The strings can include placeholders, which can
      * be used to construct a message in combination with an arbitrary number of additional string arguments.
      */
-    private MultiformatMessageString messageStrings;
+    private Map<String, MultiformatMessageString> messageStrings;
 
     /**
      * Default reporting configuration information.

--- a/src/main/java/io/codescan/sarif/model/ReportingDescriptorReference.java
+++ b/src/main/java/io/codescan/sarif/model/ReportingDescriptorReference.java
@@ -1,0 +1,33 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
+/**
+ * Information about how to locate a relevant reporting descriptor.
+ */
+public class ReportingDescriptorReference {
+    /**
+     * The id of the descriptor.
+     */
+    private String id;
+    /**
+     * The index into an array of descriptors in toolComponent.ruleDescriptors, toolComponent.notificationDescriptors,
+     * or toolComponent.taxonomyDescriptors, depending on context.
+     */
+    private Integer index;
+    /**
+     * A guid that uniquely identifies the descriptor.
+     */
+    private String guid;
+    /**
+     * A reference used to locate the toolComponent associated with the descriptor.
+     */
+    private ToolComponentReference toolComponent;
+    /**
+     * Key/value pairs that provide additional information about the reporting descriptor reference.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/ReportingDescriptorRelationship.java
+++ b/src/main/java/io/codescan/sarif/model/ReportingDescriptorRelationship.java
@@ -1,5 +1,31 @@
 package io.codescan.sarif.model;
 
-public class ReportingDescriptorRelationship {
+import lombok.Data;
+import lombok.experimental.Accessors;
 
+import java.util.Set;
+
+/**
+ * Information about the relation of one reporting descriptor to another.
+ */
+@Data
+@Accessors(chain = true)
+public class ReportingDescriptorRelationship {
+    /**
+     * A reference to the related reporting descriptor.
+     */
+    private ReportingDescriptorReference target;
+    /**
+     * A set of distinct strings that categorize the relationship. Well-known kinds include 'canPrecede', 'canFollow',
+     * 'willPrecede', 'willFollow', 'superset', 'subset', 'equal', 'disjoint', 'relevant', and 'incomparable'.
+     */
+    private Set<String> kinds;
+    /**
+     * A description of the reporting descriptor relationship.
+     */
+    private Message description;
+    /**
+     * "Key/value pairs that provide additional information about the reporting descriptor reference.
+     */
+    private PropertyBag properties;
 }

--- a/src/main/java/io/codescan/sarif/model/Result.java
+++ b/src/main/java/io/codescan/sarif/model/Result.java
@@ -1,6 +1,7 @@
 package io.codescan.sarif.model;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import lombok.Data;
@@ -17,38 +18,111 @@ public class Result {
      * The stable, unique identifier of the rule, if any, to which this result is relevant.
      */
     private String ruleId;
-
     /**
      * A reference used to locate the rule descriptor relevant to this result.
      */
     private Rule rule;
-
     /**
      * A value specifying the severity level of the result.
      */
     private Level level;
-
     /**
      * A message that describes the result. The first sentence of the message only will be displayed when visible
      * space is limited.
      */
     private Message message;
-
     /**
      * The set of locations where the result was detected. Specify only one location unless the problem indicated by
      * the result can only be corrected by making a change at every specified location.
      */
     private List<Location> locations;
-
+    /**
+     * A stable, unique identifer for the result in the form of a GUID.
+     */
     private String guid;
+    /**
+     * A stable, unique identifier for the equivalence class of logically identical results to which this result
+     * belongs, in the form of a GUID.
+     */
     private String correlationGuid;
-    private Integer occuranceCount;
+    /**
+     * A positive integer specifying the number of times this logically unique result was observed in this run.
+     */
+    private Integer occurrenceCount;
+    /**
+     * A set of strings that contribute to the stable, unique identity of the result.
+     */
+    private Map<String, String> partialFingerprint;
+    /**
+     * A set of strings each of which individually defines a stable, unique identity for the result.
+     */
+    private Map<String, String> fingerprints;
+    /**
+     * An array of 'stack' objects relevant to the result.
+     */
     private Set<Stack> stacks;
+    /**
+     * An array of 'codeFlow' objects relevant to the result.
+     */
     private List<CodeFlow> codeFlows;
+    /**
+     * An array of zero or more unique graph objects associated with the result.
+     */
+    //private Set<Graph> graphs;
+    /**
+     * An array of one or more unique 'graphTraversal' objects.
+     */
+    //private Set<GraphTraversal> graphTraversals;
+    /**
+     * A set of locations relevant to this result.
+     */
     private List<Location> relatedLocations;
+    /**
+     * A set of suppressions relevant to this result.
+     */
+    private Set<Suppression> suppressions;
+    /**
+     * The state of a result relative to a baseline of a previous run.
+     */
     private BaselineState baselineState;
+    /**
+     * A number representing the priority or importance of the result.
+     */
     private Number rank;
+    /**
+     * A set of artifacts relevant to the result.
+     */
+    //private Set<Attachment> attachments;
+    /**
+     * An absolute URI at which the result can be viewed.
+     */
     private String hostedViewerUri;
-
+    /**
+     * The URIs of the work items associated with this result.
+     */
+    private List<String> workItemUris;
+    /**
+     * Information about how and when the result was detected.
+     */
+    //private ResultProvenance provenance;
+    /**
+     * An array of 'fix' objects, each of which represents a proposed fix to the problem indicated by the result.
+     */
+    //private List<Fix> fixes;
+    /**
+     * An array of references to taxonomy reporting descriptors that are applicable to the result.
+     */
+    private List<ReportingDescriptorReference> taxa;
+    /**
+     * A web request associated with this result.
+     */
+    //private WebRequest webRequest;
+    /**
+     * A web response associated with this result
+     */
+    //private WebResponse webResponse;
+    /**
+     * Key/value pairs that provide additional information about the result
+     */
     private PropertyBag properties;
 }

--- a/src/main/java/io/codescan/sarif/model/Result.java
+++ b/src/main/java/io/codescan/sarif/model/Result.java
@@ -1,6 +1,8 @@
 package io.codescan.sarif.model;
 
 import java.util.List;
+import java.util.Set;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -22,6 +24,11 @@ public class Result {
     private Rule rule;
 
     /**
+     * A value specifying the severity level of the result.
+     */
+    private Level level;
+
+    /**
      * A message that describes the result. The first sentence of the message only will be displayed when visible
      * space is limited.
      */
@@ -32,4 +39,16 @@ public class Result {
      * the result can only be corrected by making a change at every specified location.
      */
     private List<Location> locations;
+
+    private String guid;
+    private String correlationGuid;
+    private Integer occuranceCount;
+    private Set<Stack> stacks;
+    private List<CodeFlow> codeFlows;
+    private List<Location> relatedLocations;
+    private BaselineState baselineState;
+    private Number rank;
+    private String hostedViewerUri;
+
+    private PropertyBag properties;
 }

--- a/src/main/java/io/codescan/sarif/model/Rule.java
+++ b/src/main/java/io/codescan/sarif/model/Rule.java
@@ -11,5 +11,5 @@ public class Rule {
 
     private String name;
 
-    private MultiformatMessage help;
+    private MultiformatMessageString help;
 }

--- a/src/main/java/io/codescan/sarif/model/Run.java
+++ b/src/main/java/io/codescan/sarif/model/Run.java
@@ -1,6 +1,8 @@
 package io.codescan.sarif.model;
 
 import java.util.List;
+import java.util.Map;
+
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -17,12 +19,29 @@ public class Run {
      */
     private Tool tool;
     /**
+     * Describes the invocation of the analysis tool.
+     */
+    private List<Invocation> invocations;
+    /**
+     * A conversion object that describes how a converter transformed an analysis tool's native reporting format into
+     * the SARIF format.
+     */
+    private Conversion conversion;
+    /**
      * The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter
      * lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code
      * associated with a country or region). The casing is recommended but not required (in order for this data to
      * conform to RFC5646).
      */
     private String language;
+    /**
+     * Specifies the revision in version control of the artifacts that were scanned.
+     */
+    //TODO: private List<VersionControlDetails> versionControlsProvenance;
+    /**
+     * The artifact location specified by each uriBaseId symbol on the machine where the tool originally ran.
+     */
+    private Map<String, ArtifactLocation> originalUriBaseIds;
     /**
      * An array of artifact objects relevant to the run.
      */
@@ -32,18 +51,81 @@ public class Run {
      */
     private List<LogicalLocation> logicalLocations;
     /**
+     * An array of zero or more unique graph objects associated with the run.
+     */
+    //TODO: private List<Graph> graphs;
+    /**
      * The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting
      * rules metadata. It must be present (but may be empty) if a log file represents an actual scan.
      */
     private List<Result> results;
     /**
+     * Automation details that describe this run.
+     */
+    //TODO: private RunAutomationDetails automationDetails;
+    /**
+     * Automation details that describe the aggregate of runs to which this run belongs.
+     */
+    //TODO: private List<RunAutomationDetails> runAggregates;
+    /**
      * The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result
      * 'baselineState' properties for the run.
      */
     private String baselineGuid;
-
     /**
-     * A call stack that is relevant to a result.
+     * An array of strings used to replace sensitive information in a redaction-aware property.
      */
-    private Stack stack;
+    private List<String> redactionTokens;
+    /**
+     * Specifies the default encoding for any artifact object that refers to a text file.
+     */
+    private String defaultEncoding;
+    /**
+     * Specifies the default source language for any artifact object that refers to a text file that contains source
+     * code
+     */
+    private String defaultSourceLanguage;
+    /**
+     * An ordered list of character sequences that were treated as line breaks when computing region information for
+     * the run.
+     */
+    private List<String> newlineSequences;
+    /**
+     * Specifies the unit in which the tool measures columns.
+     */
+    //TODO: private ColumnKind columnKind;
+    /**
+     * References to external property files that should be inlined with the content of a root log file.
+     */
+    //TODO: private ExternalPropertyFileReference externalPropertyFileReference;
+    /**
+     * An array of threadFlowLocation objects cached at run level.
+     */
+    private List<ThreadFlowLocation> threadFlowLocations;
+    /**
+     * An array of toolComponent objects relevant to a taxonomy in which results are categorized.
+     */
+    private List<ToolComponent> taxonomies;
+    /**
+     * Addresses associated with this run instance, if any.
+     */
+    private List<Address> addresses;
+    /**
+     * The set of available translations of the localized data provided by the tool.
+     */
+    private List<ToolComponent> translations;
+    /**
+     * Contains configurations that may potentially override both reportingDescriptor.defaultConfiguration (the tool's
+     * default severities) and invocation.configurationOverrides (severities established at run-time from the command
+     * line).
+     */
+    private List<ToolComponent> policies;
+    /**
+     * An array of request objects cached at run level.
+     */
+    //TODO: private List<WebRequest> webRequests;
+    /**
+     * An array of response objects cached at run level.
+     */
+    //TODO: private List<WebResponse> webResponses;
 }

--- a/src/main/java/io/codescan/sarif/model/Run.java
+++ b/src/main/java/io/codescan/sarif/model/Run.java
@@ -10,17 +10,40 @@ import lombok.experimental.Accessors;
 @Data
 @Accessors(chain = true)
 public class Run {
-
     /**
      * Information about the tool or tool pipeline that generated the results in this run. A run can only contain
      * results produced by a single tool or tool pipeline. A run can aggregate results from multiple log files, as long
      * as context around the tool run (tool command-line arguments and the like) is identical for all aggregated files.
      */
     private Tool tool;
-
+    /**
+     * The language of the messages emitted into the log file during this run (expressed as an ISO 639-1 two-letter
+     * lowercase culture code) and an optional region (expressed as an ISO 3166-1 two-letter uppercase subculture code
+     * associated with a country or region). The casing is recommended but not required (in order for this data to
+     * conform to RFC5646).
+     */
+    private String language;
+    /**
+     * An array of artifact objects relevant to the run.
+     */
+    private List<Artifact> artifacts;
+    /**
+     * An array of logical locations such as namespaces, types or functions.
+     */
+    private List<LogicalLocation> logicalLocations;
     /**
      * The set of results contained in an SARIF log. The results array can be omitted when a run is solely exporting
      * rules metadata. It must be present (but may be empty) if a log file represents an actual scan.
      */
     private List<Result> results;
+    /**
+     * The 'guid' property of a previous SARIF 'run' that comprises the baseline that was used to compute result
+     * 'baselineState' properties for the run.
+     */
+    private String baselineGuid;
+
+    /**
+     * A call stack that is relevant to a result.
+     */
+    private Stack stack;
 }

--- a/src/main/java/io/codescan/sarif/model/Stack.java
+++ b/src/main/java/io/codescan/sarif/model/Stack.java
@@ -1,0 +1,24 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class Stack {
+    /**
+     * A message relevant to this call stack.
+     */
+    private Message message;
+    /**
+     * An array of stack frames that represents a sequence of calls, rendered in reverse chronological order, that
+     * comprise the call stack.
+     */
+    private List<StackFrame> frames;
+    /**
+     * Key/value pairs that provide additional information about the stack.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/StackFrame.java
+++ b/src/main/java/io/codescan/sarif/model/StackFrame.java
@@ -1,0 +1,31 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.List;
+
+@Data
+@Accessors(chain = true)
+public class StackFrame {
+    /**
+     * The location to which this stack frame refers.
+     */
+    private Location location;
+    /**
+     * The name of the module that contains the code of this stack frame.
+     */
+    private String module;
+    /**
+     * The thread identifier of the stack frame.
+     */
+    private Integer threadId;
+    /**
+     * The parameters of the call that is executing.
+     */
+    private List<String> parameters;
+    /**
+     * Key/value pairs that provide additional information about the stack frame.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/Suppression.java
+++ b/src/main/java/io/codescan/sarif/model/Suppression.java
@@ -1,0 +1,36 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * A suppression that is relevant to a result.
+ */
+@Data
+@Accessors(chain = true)
+public class Suppression {
+    /**
+     * A stable, unique identifer for the suprression in the form of a GUID.
+     */
+    private String guid;
+    /**
+     * A string that indicates where the suppression is persisted.
+     */
+    //TODO: private Kind kind;
+    /**
+     * A string that indicates the review status of the suppression.
+     */
+    //TODO: private Status status;
+    /**
+     * A string representing the justification for the suppression.
+     */
+    private String justification;
+    /**
+     * Identifies the location associated with the suppression.
+     */
+    private Location location;
+    /**
+     * Key/value pairs that provide additional information about the suppression.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/ThreadFlow.java
+++ b/src/main/java/io/codescan/sarif/model/ThreadFlow.java
@@ -1,0 +1,41 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * Describes a sequence of code locations that specify a path through a single thread of execution such as an operating
+ * system or fiber.
+ */
+@Data
+@Accessors(chain = true)
+public class ThreadFlow {
+    /**
+     * An string that uniquely identifies the threadFlow within the codeFlow in which it occurs.
+     */
+    private String id;
+    /**
+     * A message relevant to the thread flow.
+     */
+    private Message message;
+    /**
+     * Values of relevant expressions at the start of the thread flow that may change during thread flow execution.
+     */
+    private Map<String, MultiformatMessageString> initialState;
+    /**
+     * Values of relevant expressions at the start of the thread flow that remain constant.
+     */
+    private Map<String, MultiformatMessageString> immutableState;
+    /**
+     * A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the
+     * tool while producing the result.
+     */
+    private Collection<ThreadFlowLocation> locations;
+    /**
+     * Key/value pairs that provide additional information about the thread flow.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/ThreadFlow.java
+++ b/src/main/java/io/codescan/sarif/model/ThreadFlow.java
@@ -3,7 +3,7 @@ package io.codescan.sarif.model;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -33,7 +33,7 @@ public class ThreadFlow {
      * A temporally ordered array of 'threadFlowLocation' objects, each of which describes a location visited by the
      * tool while producing the result.
      */
-    private Collection<ThreadFlowLocation> locations;
+    private List<ThreadFlowLocation> locations;
     /**
      * Key/value pairs that provide additional information about the thread flow.
      */

--- a/src/main/java/io/codescan/sarif/model/ThreadFlowLocation.java
+++ b/src/main/java/io/codescan/sarif/model/ThreadFlowLocation.java
@@ -1,0 +1,68 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+import java.util.Map;
+import java.util.Set;
+
+@Data
+@Accessors(chain = true)
+/**
+ * A location visited by an analysis tool while simulating or monitoring the execution of a program.
+ */
+public class ThreadFlowLocation {
+    /**
+     * The index within the run threadFlowLocations array.
+     */
+    private Integer index;
+    /**
+     * The code location.
+     */
+    private Location location;
+    /**
+     * The call stack leading to this location.
+     */
+    private Stack stack;
+    /**
+     * A set of distinct strings that categorize the thread flow location. Well-known kinds include 'acquire',
+     * 'release', 'enter', 'exit', 'call', 'return', 'branch', 'implicit', 'false', 'true', 'caution', 'danger',
+     * 'unknown', 'unreachable', 'taint', 'function', 'handler', 'lock', 'memory', 'resource', 'scope' and 'value'.
+     */
+    private Set<String> kinds;
+    /**
+     * An array of references to rule or taxonomy reporting descriptors that are applicable to the thread flow location.
+     */
+    private Set<ReportingDescriptorReference> taxa;
+    /**
+     * The name of the module that contains the code that is executing.
+     */
+    private String module;
+    /**
+     * A dictionary, each of whose keys specifies a variable or expression, the associated value of which represents
+     * the variable or expression value. For an annotation of kind 'continuation', for example, this dictionary might
+     * hold the current assumed values of a set of global variables.
+     */
+    private Map<String, MultiformatMessageString> state;
+    /**
+     * An integer representing a containment hierarchy within the thread flow.
+     */
+    private Integer nestingLevel;
+    /**
+     * An integer representing the temporal order in which execution reached this location.
+     */
+    private Integer executionOrder;
+
+    //executionTimeUtc
+
+    /**
+     * Specifies the importance of this location in understanding the code flow in which it occurs. The order from most
+     * to least important is "essential", "important", "unimportant".
+     */
+    private Importance importance;
+
+    /**
+     * Key/value pairs that provide additional information about the threadflow location.
+     */
+    private PropertyBag properties;
+}

--- a/src/main/java/io/codescan/sarif/model/ToolComponent.java
+++ b/src/main/java/io/codescan/sarif/model/ToolComponent.java
@@ -39,12 +39,12 @@ public class ToolComponent {
     /**
      * A brief description of the tool component.
      */
-    private MultiformatMessage shortDescription;
+    private MultiformatMessageString shortDescription;
 
     /**
      * A comprehensive description of the tool component.
      */
-    private MultiformatMessage fullDescription;
+    private MultiformatMessageString fullDescription;
 
     /**
      * The name of the tool component along with its version and any other useful identifying information, such as its locale.
@@ -88,7 +88,7 @@ public class ToolComponent {
      * placeholders, which can be used to construct a message in combination with an arbitrary number of additional
      * string arguments.
      */
-    private MultiformatMessage globalMessageStrings;
+    private MultiformatMessageString globalMessageStrings;
 
     /**
      * An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime

--- a/src/main/java/io/codescan/sarif/model/ToolComponent.java
+++ b/src/main/java/io/codescan/sarif/model/ToolComponent.java
@@ -1,6 +1,8 @@
 package io.codescan.sarif.model;
 
 import java.util.List;
+import java.util.Map;
+
 import lombok.Data;
 
 /**
@@ -88,7 +90,7 @@ public class ToolComponent {
      * placeholders, which can be used to construct a message in combination with an arbitrary number of additional
      * string arguments.
      */
-    private MultiformatMessageString globalMessageStrings;
+    private Map<String, MultiformatMessageString> globalMessageStrings;
 
     /**
      * An array of reportingDescriptor objects relevant to the notifications related to the configuration and runtime

--- a/src/main/java/io/codescan/sarif/model/ToolComponentReference.java
+++ b/src/main/java/io/codescan/sarif/model/ToolComponentReference.java
@@ -1,0 +1,28 @@
+package io.codescan.sarif.model;
+
+import lombok.Data;
+import lombok.experimental.Accessors;
+
+/**
+ * Identifies a particular toolComponent object, either the driver or an extension.
+ */
+@Data
+@Accessors(chain = true)
+public class ToolComponentReference {
+    /**
+     * The 'name' property of the referenced toolComponent.
+     */
+    private String name;
+    /**
+     * An index into the referenced toolComponent in tool.extensions.
+     */
+    private Integer index;
+    /**
+     * The 'guid' property of the referenced toolComponent.
+     */
+    private String guid;
+    /**
+     * Key/value pairs that provide additional information about the toolComponentReference.
+     */
+    private PropertyBag properties;
+}

--- a/src/test/java/io/codescan/sarif/encoding/InstantSerializerTests.java
+++ b/src/test/java/io/codescan/sarif/encoding/InstantSerializerTests.java
@@ -26,9 +26,15 @@ public class InstantSerializerTests {
     }
 
     @Test
-    public void GivenEmptyInstant_WhenSerialized_ThenIsISO8601FormattedInUTC() throws IOException {
+    public void GivenEPOCHInstant_WhenSerialized_ThenIsISO8601FormattedInUTC() throws IOException {
         var instant = Instant.EPOCH;
         check(instant, "1970-01-01T00:00:00Z");
+    }
+
+    @Test
+    public void GivenInstantWithLeapYear_WhenSerialized_ThenIsISO8601Formatted() throws IOException {
+        var instant = ZonedDateTime.parse("2020-02-29T08:00:00+00:00[UTC]").toInstant();
+        check(instant, "2020-02-29T08:00:00Z");
     }
 
     public void check(Instant given, String expected) throws IOException {
@@ -37,9 +43,7 @@ public class InstantSerializerTests {
 
         JsonNode actualJson = mapper.readTree("{\"test\" : " + instantJson + "}");
         JsonNode expectedJson = mapper.readTree(new StringBuilder()
-                .append("{")
-                .append("\"test\": \"" + expected + "\"")
-                .append("}")
+                .append("{\"test\": \"" + expected + "\"}")
                 .toString());
 
         assertEquals(expectedJson, actualJson);

--- a/src/test/java/io/codescan/sarif/encoding/InstantSerializerTests.java
+++ b/src/test/java/io/codescan/sarif/encoding/InstantSerializerTests.java
@@ -1,0 +1,47 @@
+package io.codescan.sarif.encoding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codescan.sarif.model.PropertyBag;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InstantSerializerTests {
+
+    @Test
+    public void GivenInstantInUTC_WhenSerialized_ThenIsISO8601Formatted() throws IOException {
+        var instant = ZonedDateTime.parse("2018-09-16T08:00:00+00:00[UTC]").toInstant();
+        check(instant, "2018-09-16T08:00:00Z");
+    }
+
+    @Test
+    public void GivenInstantInNonUTC_WhenSerialized_ThenIsISO8601FormattedInUTC() throws IOException {
+        var instant = ZonedDateTime.parse("2018-09-16T08:00:00+01:00[Europe/Paris]").toInstant();
+        check(instant, "2018-09-16T07:00:00Z");
+    }
+
+    @Test
+    public void GivenEmptyInstant_WhenSerialized_ThenIsISO8601FormattedInUTC() throws IOException {
+        var instant = Instant.EPOCH;
+        check(instant, "1970-01-01T00:00:00Z");
+    }
+
+    public void check(Instant given, String expected) throws IOException {
+        var mapper = new ObjectMapper();
+        var instantJson = SarifJsonSerializer.toJson(given);
+
+        JsonNode actualJson = mapper.readTree("{\"test\" : " + instantJson + "}");
+        JsonNode expectedJson = mapper.readTree(new StringBuilder()
+                .append("{")
+                .append("\"test\": \"" + expected + "\"")
+                .append("}")
+                .toString());
+
+        assertEquals(expectedJson, actualJson);
+    }
+}

--- a/src/test/java/io/codescan/sarif/encoding/PropertyBagSerializerTests.java
+++ b/src/test/java/io/codescan/sarif/encoding/PropertyBagSerializerTests.java
@@ -9,7 +9,7 @@ import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class SarifJsonSerializerTests {
+public class PropertyBagSerializerTests {
 
     @Test
     public void propertyBagArbitraryKVs() throws Exception {

--- a/src/test/java/io/codescan/sarif/encoding/SarifJsonSerializerTests.java
+++ b/src/test/java/io/codescan/sarif/encoding/SarifJsonSerializerTests.java
@@ -1,0 +1,153 @@
+package io.codescan.sarif.encoding;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.codescan.sarif.model.PropertyBag;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class SarifJsonSerializerTests {
+
+    @Test
+    public void propertyBagArbitraryKVs() throws Exception {
+        var bag = new PropertyBag();
+        LinkedHashSet<String> tags = new LinkedHashSet<String>();
+        tags.add("foo");
+        tags.add("bar");
+        tags.add("quux");
+        tags.add("qaaz");
+        bag.setTags(tags);
+        Map<String, String> m = new HashMap();
+        m.put("akey", "aval");
+        m.put("bkey", "bval");
+        bag.setProperties(m);
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"akey\": \"aval\",")
+                .append("\"bkey\": \"bval\",")
+                .append("\"tags\": [\"foo\", \"bar\", \"quux\", \"qaaz\"]}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GivenNullTags_WhenToJson_ThenNoTagsAreShown() throws Exception {
+        var bag = new PropertyBag();
+        Map<String, String> m = new HashMap();
+        m.put("akey", "aval");
+        m.put("bkey", "bval");
+        bag.setProperties(m);
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"akey\": \"aval\",")
+                .append("\"bkey\": \"bval\"}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+    @Test
+    public void GivenEmptyTags_WhenToJson_ThenEmptyTagsAreShown() throws Exception {
+        var bag = new PropertyBag();
+        Map<String, String> m = new HashMap();
+        m.put("akey", "aval");
+        m.put("bkey", "bval");
+        bag.setProperties(m);
+        bag.setTags(new LinkedHashSet<String>());
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"akey\": \"aval\",")
+                .append("\"bkey\": \"bval\",")
+                .append("\"tags\": []}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GivenEmptyProps_WhenToJson_ThenNoPropsAreShown() throws Exception {
+        var bag = new PropertyBag();
+        Map<String, String> m = new HashMap();
+        bag.setProperties(m);
+        var tags = new LinkedHashSet<String>();
+        tags.add("foo");
+        tags.add("bar");
+        bag.setTags(tags);
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"tags\": [\"foo\", \"bar\"]}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GivenNullProps_WhenToJson_ThenNoPropsAreShown() throws Exception {
+        var bag = new PropertyBag();
+        var tags = new LinkedHashSet<String>();
+        tags.add("foo");
+        tags.add("bar");
+        bag.setTags(tags);
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"tags\": [\"foo\", \"bar\"]}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GivenNullPropsAndTags_WhenToJson_ThenNoPropsOrTagsAreShown() throws Exception {
+        var bag = new PropertyBag();
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void GivenEmptyPropsAndTags_WhenToJson_ThenEmptyTagsAreOnlyShown() throws Exception {
+        var bag = new PropertyBag();
+        bag.setProperties(new HashMap<String, String>());
+        bag.setTags(new LinkedHashSet<String>());
+
+        var bagJson = SarifJsonSerializer.toJson(bag);
+
+        JsonNode actual = new ObjectMapper().readTree(bagJson);
+        JsonNode expected = new ObjectMapper().readTree(new StringBuilder()
+                .append("{")
+                .append("\"tags\":[]}")
+                .toString());
+
+        assertEquals(expected, actual);
+    }
+}


### PR DESCRIPTION
data models forked from CodeScan LLC and extended to support more of the standard SARIF.  Here is the SARIF specification for reference: 
* https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json
* https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.htm

Note that while it supports most of the standard sarif data model, it doesn't support all of it.  Its also only a barebones logical model that serializes to standard sarif correctly.  Anything like smart descriptor references and whatnot would need to be added or built on top.